### PR TITLE
Update the CORS policy in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,15 +37,21 @@ IAM policy granting read access:
 ```
 
 A sufficient CORS policy can look like this:
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
-<CORSRule>
-    <AllowedOrigin>*</AllowedOrigin>
-    <AllowedMethod>GET</AllowedMethod>
-    <AllowedHeader>*</AllowedHeader>
-</CORSRule>
-</CORSConfiguration>
+```json
+[
+    {
+        "AllowedHeaders": [
+            "*"
+        ],
+        "AllowedMethods": [
+            "GET"
+        ],
+        "AllowedOrigins": [
+            "*"
+        ],
+        "ExposeHeaders": []
+    }
+]
 ```
 
 Besides configuring an S3 bucket for reads you will probably want to


### PR DESCRIPTION
According to [CORS configuration](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ManageCorsUsing.html), from now on CORS settings can only be configured using JSON.